### PR TITLE
[FE-163] Fix featured workspace tests

### DIFF
--- a/cleanup_workspaces.py
+++ b/cleanup_workspaces.py
@@ -13,7 +13,7 @@ def cleanup_workspaces(project, match_str=None, age_days=None, verbose=True):
     exceptions = []
     
     # get a list of all workspaces in the project
-    ws_json = call_fiss(fapi.list_workspaces, 200)
+    ws_json = call_fiss(fapi.list_workspaces, 200, fields='workspace.name,workspace.namespace')
     ws_all = []
     for ws in ws_json:
         ws_project = ws['workspace']['namespace']
@@ -52,10 +52,13 @@ def cleanup_workspaces(project, match_str=None, age_days=None, verbose=True):
                     ws_to_delete.add(ws)
     
     # delete those old workspaces
+    n_total = len(ws_to_delete)
+    n_done = 0
     for ws in ws_to_delete:
-        call_fiss(fapi.delete_workspace, 202, project, ws)
+        n_done += 1
+        call_fiss(fapi.delete_workspace, 202, project, ws, specialcodes=[404])  # a 404 means the workspace isn't found - already deleted
         if verbose:
-            print(ws + ' deleted')
+            print(ws + ' deleted (' + str(n_done) + '/' + str(n_total) + ')')
 
 
 

--- a/fiss_api_addons.py
+++ b/fiss_api_addons.py
@@ -100,6 +100,7 @@ def clone_workspace_with_bucket_location(from_namespace, from_workspace, to_name
         from_workspace (str): Source workspace's name
         to_namespace (str):  project to which target workspace belongs
         to_workspace (str): Target workspace's name
+        bucketLocation (str): Target workspace's bucket location
         authorizationDomain: (str) required authorization domains
         copyFilesWithPrefix: (str) prefix of bucket objects to copy to the destination workspace
 

--- a/fiss_api_addons.py
+++ b/fiss_api_addons.py
@@ -88,3 +88,43 @@ def get_workspace_cloudPlatform(namespace, name):
     request_url = f'https://api.firecloud.org/api/workspaces/{namespace}/{name}?fields=workspace.cloudPlatform'
 
     return fapi.__get(request_url)
+
+def clone_workspace_with_bucket_location(from_namespace, from_workspace, to_namespace, to_workspace, bucketLocation, authorizationDomain="", copyFilesWithPrefix=None):
+    """Clone a FireCloud workspace.
+
+    A clone is a shallow copy of a FireCloud workspace, enabling
+    easy sharing of data, such as TCGA data, without duplication.
+
+    Args:
+        from_namespace (str):  project (namespace) to which source workspace belongs
+        from_workspace (str): Source workspace's name
+        to_namespace (str):  project to which target workspace belongs
+        to_workspace (str): Target workspace's name
+        authorizationDomain: (str) required authorization domains
+        copyFilesWithPrefix: (str) prefix of bucket objects to copy to the destination workspace
+
+    Swagger:
+        https://api.firecloud.org/#!/Workspaces/cloneWorkspace
+    """
+
+    if authorizationDomain:
+        if isinstance(authorizationDomain, string_types):
+            authDomain = [{"membersGroupName": authorizationDomain}]
+        else:
+            authDomain = [{"membersGroupName": authDomain} for authDomain in authorizationDomain]
+    else:
+        authDomain = []
+
+    body = {
+        "namespace": to_namespace,
+        "name": to_workspace,
+        "attributes": dict(),
+        "bucketLocation": bucketLocation,
+        "authorizationDomain": authDomain,
+    }
+
+    if copyFilesWithPrefix is not None:
+        body["copyFilesWithPrefix"] = copyFilesWithPrefix
+
+    uri = "workspaces/{0}/{1}/clone".format(from_namespace, from_workspace)
+    return fapi.__post(uri, json=body)

--- a/fiss_fns.py
+++ b/fiss_fns.py
@@ -39,7 +39,7 @@ def call_fiss(fapifunc, okcode, *args, specialcodes=None, **kwargs):
     function returns:
         response.json() : json response of the api call if successful
         OR
-        response : non-parsed API response if you submitted specialcodes
+        response : non-parsed API response if you submitted specialcodes or if calling .json throws an exception
 
     example use:
         output = call_fiss(fapi.get_workspace, 200, 'help-gatk', 'Sequence-Format-Conversion')

--- a/fiss_fns.py
+++ b/fiss_fns.py
@@ -61,7 +61,11 @@ def call_fiss(fapifunc, okcode, *args, specialcodes=None, **kwargs):
         return response
 
     # return the json response if all goes well
-    return response.json()
+    try:
+        return response.json()
+    except:
+        # not all responses are json
+        return response
 
 
 def format_timedelta(time_delta, hours_thresh):

--- a/workspace_test_report.py
+++ b/workspace_test_report.py
@@ -7,6 +7,7 @@ from ws_class import Wspace
 from firecloud import api as fapi
 from fiss_fns import call_fiss
 from gcs_fns import run_subprocess
+from fiss_api_addons import clone_workspace_with_bucket_location
 
 
 def get_ws_bucket(project, name):
@@ -40,12 +41,13 @@ def clone_workspace(original_project, original_name, clone_project, clone_name=N
     original_owners = response['owners']
 
     # clone the Featured Workspace & check for errors
-    call_fiss(fapi.clone_workspace,
+    call_fiss(clone_workspace_with_bucket_location,
               201,
               original_project,
               original_name,
               clone_project,
               clone_name,
+              bucketLocation='us-central1',
               specialcodes=[409])  # 409 = workspace already exists
 
     # optionally copy entire bucket, including notebooks


### PR DESCRIPTION
This PR incorporates Morgan's fix for the workspace cleanup and adds changes to the `clone_workspace` [firecloud api function](https://github.com/broadinstitute/fiss/blob/e973cbd58ce9bde43e537318c5dc244a0256b446/firecloud/api.py#L1516) to allow for specific location for the target workspace bucket. 

Currently, some featured workspaces are still in us-multiregion so when they are cloned for testing, those clones also get created in us-multiregion. [Per Adam](https://broadinstitute.slack.com/archives/CN5K96NMV/p1707924218201059), this will cost more starting March 15, so these workspaces should be getting cloned to us-central1.

